### PR TITLE
Added Japanese version's opcodes

### DIFF
--- a/vc/VCSCM.INI
+++ b/vc/VCSCM.INI
@@ -1010,6 +1010,11 @@ DATE=2021-05-25
 05a7=4,set_object %1d% velocity %2d% %3d% %4d%  ;; never used in VC
 05a8=2,get_object %1d% speed_to %2d%  ;; never used in VC
 
+;TODO: Japanese version opcodes
+;5f4e=
+;7ff8=
+;7ffd=
+
 ; CLEO 1.1 opcodes
 05dc=0,terminate_this_custom_script
 05dd=1,terminate_all_custom_scripts_with_this_name %1s%


### PR DESCRIPTION
When I tried opening the MAIN.SCM of VC's Japanese version (after converting w/ xdelta3 from this link (https://www.speedrun.com/gtavc/resources)), I saw it pop up unknown opcodes in SannyBuilder. These are 5F4E, 7FF8, and 7FFD. There may be more, but I'm just gonna put this up and include the JP main.scm!

```:Label114526
00D6: if 
059C: NOP 'M' 21831 
hex
 "N_H2" 00
end
0200:   player // never used in VC 
8601:   not is_button_pressed_on_pad '¿' with_sensitivity '_H1' 
0200:   player 'À
Ä
È
Ì
Ö' near_car_on_foot $883 radius 'Ö' 10 '' unknown // never used in VC 
hex
 01 B5 BF 01 00 0C
end
0200:   player 'L
Ö' near_car_on_foot 'á' radius $880 100 'M' unknown // never used in VC 
hex
 02 4C
end
```

[mainJAPANESE.txt](https://github.com/sannybuilder/data/files/8582359/mainJAPANESE.txt)