### PR TITLE
Define types of variables $player1 and $scplayer

### DIFF
--- a/gta3_sbl/constants.txt
+++ b/gta3_sbl/constants.txt
@@ -1,10 +1,13 @@
 const
-false=0
-true=1
-TIMERA=16@
-TIMERB=17@
+    false = 0
+    true = 1
 end
-var
-TIMERA: int
-TIMERB: int
-end
+
+const TIMERA = 16@
+var TIMERA: int
+
+const TIMERB = 17@
+var TIMERB: int
+
+var $player1: Player
+var $scplayer: Char

--- a/sa_sbl/constants.txt
+++ b/sa_sbl/constants.txt
@@ -1,10 +1,14 @@
 const
-false=0
-true=1
-TIMERA=32@
-TIMERB=33@
+    false = 0
+    true = 1
 end
-var
-TIMERA: int
-TIMERB: int
-end
+
+const TIMERA = 32@
+var TIMERA: int
+
+const TIMERB = 33@
+var TIMERB: int
+
+var $player1: Player
+var $scplayer: Char
+var $players_group: Group

--- a/vc_sbl/constants.txt
+++ b/vc_sbl/constants.txt
@@ -1,10 +1,13 @@
 const
-false=0
-true=1
-TIMERA=16@
-TIMERB=17@
+    false = 0
+    true = 1
 end
-var
-TIMERA: int
-TIMERB: int
-end
+
+const TIMERA = 16@
+var TIMERA: int
+
+const TIMERB = 17@
+var TIMERB: int
+
+var $player1: Player
+var $scplayer: Char


### PR DESCRIPTION
Define types for most common global variables:
* $player1
* $scplayer
* $players_group (GTA SA)

Enables usage of class syntax like:
```
$player1.AddScore(50)
$scplayer.AddArmor(50)
```